### PR TITLE
feat(remove-duplicates-from-sorted-array): 

### DIFF
--- a/remove-duplicates-from-sorted-array/README.md
+++ b/remove-duplicates-from-sorted-array/README.md
@@ -1,0 +1,2 @@
+# 26. Remove Duplicates from Sorted Array
+See. https://leetcode.com/problems/remove-duplicates-from-sorted-array/

--- a/remove-duplicates-from-sorted-array/removeDuplicates.go
+++ b/remove-duplicates-from-sorted-array/removeDuplicates.go
@@ -1,16 +1,20 @@
 package removeduplicatesfromsortedarray
 
+import "log"
+
 func removeDuplicates(nums []int) int {
-	seen := make(map[int]bool)
-	for i, n := range nums {
-		if i == 0 {
-			nums = nums[:0]
-		}
-		if !seen[n] {
-			seen[n] = true
-			nums = append(nums, n)
-		}
+	if len(nums) < 2 {
+		return len(nums)
 	}
-	nums = nums[:len(nums)]
-	return len(nums)
+
+	i := 0
+	for _, v := range nums[1:] {
+		if v == nums[i] {
+			continue
+		}
+		nums[i+1] = v
+		i++
+	}
+	log.Println(nums)
+	return i + 1
 }

--- a/remove-duplicates-from-sorted-array/removeDuplicates.go
+++ b/remove-duplicates-from-sorted-array/removeDuplicates.go
@@ -1,0 +1,9 @@
+package removeduplicatesfromsortedarray
+
+func removeDuplicates(nums []int) int {
+	m := make(map[int]int, 0)
+	for _, n := range nums {
+		m[n]++
+	}
+	return len(m)
+}

--- a/remove-duplicates-from-sorted-array/removeDuplicates.go
+++ b/remove-duplicates-from-sorted-array/removeDuplicates.go
@@ -1,7 +1,5 @@
 package removeduplicatesfromsortedarray
 
-import "log"
-
 func removeDuplicates(nums []int) int {
 	if len(nums) < 2 {
 		return len(nums)
@@ -15,6 +13,5 @@ func removeDuplicates(nums []int) int {
 		nums[i+1] = v
 		i++
 	}
-	log.Println(nums)
 	return i + 1
 }

--- a/remove-duplicates-from-sorted-array/removeDuplicates.go
+++ b/remove-duplicates-from-sorted-array/removeDuplicates.go
@@ -1,9 +1,16 @@
 package removeduplicatesfromsortedarray
 
 func removeDuplicates(nums []int) int {
-	m := make(map[int]int, 0)
-	for _, n := range nums {
-		m[n]++
+	seen := make(map[int]bool)
+	for i, n := range nums {
+		if i == 0 {
+			nums = nums[:0]
+		}
+		if !seen[n] {
+			seen[n] = true
+			nums = append(nums, n)
+		}
 	}
-	return len(m)
+	nums = nums[:len(nums)]
+	return len(nums)
 }

--- a/remove-duplicates-from-sorted-array/removeDuplicates_test.go
+++ b/remove-duplicates-from-sorted-array/removeDuplicates_test.go
@@ -1,0 +1,26 @@
+package removeduplicatesfromsortedarray
+
+import (
+	"fmt"
+	"testing"
+)
+
+var cases = []struct {
+	id    int
+	input []int
+	want  int
+}{
+	{id: 1, input: []int{1, 1, 2}, want: 2},
+	{id: 2, input: []int{0, 0, 1, 1, 1, 2, 2, 3, 3, 4}, want: 5},
+}
+
+func TestRemoveDupulicates(t *testing.T) {
+	for _, tt := range cases {
+		t.Run(fmt.Sprint(tt.id), func(t *testing.T) {
+			got := removeDuplicates(tt.input)
+			if got != tt.want {
+				t.Errorf("%d, want: %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/remove-duplicates-from-sorted-array/removeDuplicates_test.go
+++ b/remove-duplicates-from-sorted-array/removeDuplicates_test.go
@@ -21,7 +21,7 @@ func TestRemoveDupulicates(t *testing.T) {
 		t.Run(fmt.Sprint(tt.id), func(t *testing.T) {
 			got := removeDuplicates(tt.input)
 			nums := tt.input
-			if !reflect.DeepEqual(nums, tt.wantList) {
+			if !reflect.DeepEqual(nums[:got], tt.wantList) {
 				t.Errorf("%v, wantList: %v", nums, tt.wantList)
 			}
 			if got != tt.wantLength {

--- a/remove-duplicates-from-sorted-array/removeDuplicates_test.go
+++ b/remove-duplicates-from-sorted-array/removeDuplicates_test.go
@@ -2,24 +2,30 @@ package removeduplicatesfromsortedarray
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 )
 
 var cases = []struct {
-	id    int
-	input []int
-	want  int
+	id         int
+	input      []int
+	wantList   []int
+	wantLength int
 }{
-	{id: 1, input: []int{1, 1, 2}, want: 2},
-	{id: 2, input: []int{0, 0, 1, 1, 1, 2, 2, 3, 3, 4}, want: 5},
+	{id: 1, input: []int{1, 1, 2}, wantList: []int{1, 2}, wantLength: 2},
+	{id: 2, input: []int{0, 0, 1, 1, 1, 2, 2, 3, 3, 4}, wantList: []int{0, 1, 2, 3, 4}, wantLength: 5},
 }
 
 func TestRemoveDupulicates(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(fmt.Sprint(tt.id), func(t *testing.T) {
 			got := removeDuplicates(tt.input)
-			if got != tt.want {
-				t.Errorf("%d, want: %d", got, tt.want)
+			nums := tt.input
+			if !reflect.DeepEqual(nums, tt.wantList) {
+				t.Errorf("%v, wantList: %v", nums, tt.wantList)
+			}
+			if got != tt.wantLength {
+				t.Errorf("%d, wantLength: %d", got, tt.wantLength)
 			}
 		})
 	}


### PR DESCRIPTION
## first submit version
- 単にマップを作成
- 整数配列をループして、キーの数値をマップに突っ込む
- ループが終了したらマップの長さを返す

## Second submit version
- mapを作成してキーがあるかどうかチェック
- ループでスライスの要素をチェックする際、
    - ０番目はマップにキーが存在するか判定せずに同じスライスに突っ込む
    - マップに要素がキーとして存在するか確認
       - なければ、マップにキーを値はTrueとして追加
       - 同じスライスにも値を追加
   - ループが終わった後、スライスの長さ分だけ切り取る
   - 戻り値としてスライスの長さを返す

## 3rd submit version
- そもそもの要件に、`Do not allocate extra space for another array, you must do this by modifying the input array in-place with O(1) extra memory.` とある為、上記解法は不適切と判断。
- 別解法を考察したが、出てこないので、他の方のaccepted solutionを確認
- 頭に入ってきた解決方法をcommit
  - スライス長が２以下なら何もせず、戻り値としてスライス長を返す
  - カウンターとしてiを0で定義
  - スライスを1番目からループ
     - iで指定の0番目のスライスの値とループで得られる値の1番目と同じなら何もせずループをコンティニュー
     - 上記に合致しない場合は、iで指定した番号をインクリメントしたスライス番号にループで得られる値を設定
     - iをインクリメント
  - 新しいスライスの長さは、カウンターに1足した数なのでその値を戻り値として返す

- テストケースがFAILになる問題があったが、workaroundとして、戻り値のスライス長で、スライスを切り取って比較させるように変更