### PR TITLE
feat(binary-tree-preorder-traversal)

### DIFF
--- a/problems/binary-tree-preorder-traversal/solution.go
+++ b/problems/binary-tree-preorder-traversal/solution.go
@@ -8,16 +8,23 @@ type TreeNode struct {
 }
 
 func preorderTraversal(root *TreeNode) []int {
-	acc := make([]int, 0)
-	preorderRecursive(&acc, root)
-	return acc
-}
-
-func preorderRecursive(acc *[]int, root *TreeNode) {
+	ans := make([]int, 0)
 	if root == nil {
-		return
+		return ans
 	}
-	*acc = append(*acc, root.Val)
-	preorderRecursive(acc, root.Left)
-	preorderRecursive(acc, root.Right)
+	stack := make([]*TreeNode, 0)
+	stack = append(stack, root)
+
+	for len(stack) != 0 {
+		visit := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		ans = append(ans, visit.Val)
+		if visit.Right != nil {
+			stack = append(stack, visit.Right)
+		}
+		if visit.Left != nil {
+			stack = append(stack, visit.Left)
+		}
+	}
+	return ans
 }

--- a/problems/binary-tree-preorder-traversal/solution.go
+++ b/problems/binary-tree-preorder-traversal/solution.go
@@ -1,0 +1,23 @@
+package main
+
+// TreeNode is definition for a binary tree node
+type TreeNode struct {
+	Val   int
+	Left  *TreeNode
+	Right *TreeNode
+}
+
+func preorderTraversal(root *TreeNode) []int {
+	acc := make([]int, 0)
+	preorderRecursive(&acc, root)
+	return acc
+}
+
+func preorderRecursive(acc *[]int, root *TreeNode) {
+	if root == nil {
+		return
+	}
+	*acc = append(*acc, root.Val)
+	preorderRecursive(acc, root.Left)
+	preorderRecursive(acc, root.Right)
+}

--- a/problems/binary-tree-preorder-traversal/solution.go
+++ b/problems/binary-tree-preorder-traversal/solution.go
@@ -28,3 +28,5 @@ func preorderTraversal(root *TreeNode) []int {
 	}
 	return ans
 }
+
+func main() {}

--- a/problems/binary-tree-preorder-traversal/solution_test.go
+++ b/problems/binary-tree-preorder-traversal/solution_test.go
@@ -13,6 +13,8 @@ type Case struct {
 
 var cases = []Case{
 	{input: []interface{}{1, nil, 2, 3}, want: []int{1, 2, 3}},
+	{input: []interface{}{}, want: []int{}},
+	{input: []interface{}{3, 1, 2}, want: []int{3, 1, 2}},
 }
 
 func TestPreorderTravarsal(t *testing.T) {

--- a/problems/binary-tree-preorder-traversal/solution_test.go
+++ b/problems/binary-tree-preorder-traversal/solution_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+type Case struct {
+	input []interface{}
+	want  []int
+}
+
+var cases = []Case{
+	{input: []interface{}{1, nil, 2, 3}, want: []int{1, 2, 3}},
+}
+
+func TestPreorderTravarsal(t *testing.T) {
+	for i, tt := range cases {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			got := preorderTraversal(arr2TreeNode(tt.input))
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("%v, want: %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func arr2TreeNode(arr []interface{}) *TreeNode {
+	var n *TreeNode
+	for _, a := range arr {
+		n = insert(n, a)
+	}
+	return n
+}
+
+func insert(n *TreeNode, data interface{}) *TreeNode {
+	if n == nil {
+		return &TreeNode{data.(int), nil, nil}
+	}
+	if data == nil {
+		return n
+	}
+
+	if data.(int) < n.Val {
+		n.Left = insert(n.Left, data)
+	} else {
+		n.Right = insert(n.Right, data)
+	}
+	return n
+}


### PR DESCRIPTION
 I couldn't self solve this problem.

## Introduction
Pre-order traversal is to visit the root first. Then traverse the left subtree. Finally, traverse the right subtree.

## Approach 1
recursive


```golang
func preorderTraversal(root *TreeNode) []int {
	acc := make([]int, 0)
	preorderRecursive(&acc, root)
	return acc
}

func preorderRecursive(acc *[]int, root *TreeNode) {
	if root == nil {
		return
	}
	*acc = append(*acc, root.Val)
	preorderRecursive(acc, root.Left)
	preorderRecursive(acc, root.Right)
}
```
## Approach 2
Iterative method with Stack

```golang
func preorderTraversal(root *TreeNode) []int {
        ans := make([]int, 0)
        if root == nil {
                return ans 
        }
        stack := make([]*TreeNode, 0)
        stack = append(stack, root)

        for len(stack) != 0 {
                visit := stack[len(stack)-1]
                stack = stack[:len(stack)-1]
                ans = append(ans, visit.Val)

                if visit.Left != nil {
                        stack = append(stack, visit.Left)
                }
                if visit.Right != nil {
                        stack = append(stack, visit.Right)
                }
                 
        }
        return ans
}
```