### PR TITLE
feat(binary-tree-postorder-traversal): Approach: Iterative method with Stack

### DIFF
--- a/problems/binary-tree-postorder-traversal/solution.go
+++ b/problems/binary-tree-postorder-traversal/solution.go
@@ -1,0 +1,31 @@
+package binarytreepostordertraversal
+
+type TreeNode struct {
+	Val   int
+	Left  *TreeNode
+	Right *TreeNode
+}
+
+func postorderTraversal(root *TreeNode) []int {
+	ans := make([]int, 0)
+	if root == nil {
+		return ans
+	}
+	stack := make([]*TreeNode, 0)
+	stack = append(stack, root)
+
+	for len(stack) != 0 {
+		visit := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+
+		if visit.Left != nil {
+			stack = append(stack, visit.Left)
+		}
+
+		if visit.Right != nil {
+			stack = append(stack, visit.Right)
+		}
+		ans = append([]int{visit.Val}, ans...)
+	}
+	return ans
+}

--- a/problems/binary-tree-postorder-traversal/solution_test.go
+++ b/problems/binary-tree-postorder-traversal/solution_test.go
@@ -1,0 +1,52 @@
+package binarytreepostordertraversal
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+type Case struct {
+	input []interface{}
+	want  []int
+}
+
+var cases = []Case{
+	{input: []interface{}{1, nil, 2, 3}, want: []int{3, 2, 1}},
+}
+
+func TestPostorderTraversal(t *testing.T) {
+	for i, tt := range cases {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			got := postorderTraversal(slice2TreeNode(tt.input))
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("%v, want: %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func slice2TreeNode(sl []interface{}) *TreeNode {
+	var n *TreeNode
+	for _, s := range sl {
+		n = insert(n, s)
+	}
+	return n
+}
+
+func insert(n *TreeNode, data interface{}) *TreeNode {
+	if n == nil {
+		return &TreeNode{data.(int), nil, nil}
+	}
+
+	if data == nil {
+		return n
+	}
+
+	if data.(int) < n.Val {
+		n.Left = insert(n.Left, data)
+	} else {
+		n.Right = insert(n.Right, data)
+	}
+	return n
+}


### PR DESCRIPTION
I couldn't self solve this problem

## Introduction
Post-order traversal is to traverse the left subtree first. Then traverse the right subtree. Finally, visit the root.

## Approach 2
Iterative method with Stack

```golang
 func postorderTraversal(root *TreeNode) []int {
          ans := make([]int, 0)
          if root == nil {
                  return ans
          }
          stack := make([]*TreeNode, 0)
          stack = append(stack, root)
  
          for len(stack) != 0 {
                  visit := stack[len(stack)-1]
                  stack = stack[:len(stack)-1]
  
                  if visit.Left != nil {
                          stack = append(stack, visit.Left)
                  }
  
                  if visit.Right != nil {
                          stack = append(stack, visit.Right)
                  }
                  ans = append([]int{visit.Val}, ans...)
          }
          return ans
  }
```

### refarence
- https://leetcode.com/problems/binary-tree-postorder-traversal/discuss/45761/C++-Iterative-solution-one-stack