### PR TITLE
Maximum Width of Binary Tree: dfs solution

### DIFF
--- a/explore/other/card/july-leetcoding-challenge/week-2/maximumwidthofbinarytree/solution.go
+++ b/explore/other/card/july-leetcoding-challenge/week-2/maximumwidthofbinarytree/solution.go
@@ -1,0 +1,38 @@
+package maximumwidthofbinarytree
+
+type TreeNode struct {
+	Val   int
+	Left  *TreeNode
+	Right *TreeNode
+}
+
+// https://leetcode.com/problems/maximum-width-of-binary-tree/discuss/106654/JavaC++-Very-simple-dfs-solution
+func widthOfBinaryTree(root *TreeNode) int {
+	start := []int{}
+	end := []int{}
+
+	var dfs func(node *TreeNode, d, o int) int
+	dfs = func(node *TreeNode, d, o int) int {
+		if node == nil {
+			return 0
+		}
+		if len(start) == d {
+			start = append(start, o)
+			end = append(end, o)
+		} else {
+			end[d] = o
+		}
+		cur := end[d] - start[d] + 1
+		left := dfs(node.Left, d+1, 2*o)
+		right := dfs(node.Right, d+1, 2*o+1)
+		return max(cur, max(left, right))
+	}
+	return dfs(root, 0, 1)
+}
+
+func max(x, y int) int {
+	if x > y {
+		return x
+	}
+	return y
+}

--- a/explore/other/card/july-leetcoding-challenge/week-2/maximumwidthofbinarytree/solution_test.go
+++ b/explore/other/card/july-leetcoding-challenge/week-2/maximumwidthofbinarytree/solution_test.go
@@ -1,0 +1,74 @@
+package maximumwidthofbinarytree
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestWidthOfVinaryTree(t *testing.T) {
+	tests := []struct {
+		in   *TreeNode
+		want int
+	}{
+		{in: &TreeNode{
+			Val: 1,
+			Left: &TreeNode{
+				Val:   3,
+				Left:  &TreeNode{Val: 5},
+				Right: &TreeNode{Val: 3},
+			},
+			Right: &TreeNode{
+				Val:   2,
+				Right: &TreeNode{Val: 9},
+			},
+		},
+			want: 4},
+		{
+			in: &TreeNode{
+				Val: 1,
+				Left: &TreeNode{
+					Val:   3,
+					Left:  &TreeNode{Val: 5},
+					Right: &TreeNode{Val: 3},
+				},
+			},
+			want: 2},
+		{
+			in: &TreeNode{
+				Val: 1,
+				Left: &TreeNode{
+					Val:  3,
+					Left: &TreeNode{Val: 5},
+				},
+				Right: &TreeNode{
+					Val: 2,
+				}},
+			want: 2},
+		{
+			in: &TreeNode{
+				Val: 1,
+				Left: &TreeNode{
+					Val: 3,
+					Left: &TreeNode{
+						Val: 5,
+						Left: &TreeNode{
+							Val: 6}}},
+				Right: &TreeNode{
+					Val: 2,
+					Right: &TreeNode{
+						Val: 9,
+						Right: &TreeNode{
+							Val: 7}}}},
+			want: 8},
+	}
+	for i, tt := range tests {
+		i, tt := i, tt
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			t.Parallel()
+			got := widthOfBinaryTree(tt.in)
+			if got != tt.want {
+				t.Fatalf("in: %v got: %v want: %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Intuition
バイナリツリーはスライスで表現できます。（ルートはスライスのインデックス１から始まると仮定します）
ノードのインデックスをiとすると、そ２つの子のインデックスは2*iと2*i+1になります。
2つのスライス（startとend）を使用して各レベルの左端のノードと右端のノードのインデックスをそれぞれ記録します。
ツリーの各レベルについては、幅はend[level] - start[level] + 1となります。

あとは最大の幅を求めるだけです。