### PR TITLE
Vertical Order Traversal of a Binary Tree: seen discuss

### DIFF
--- a/explore/other/card/august-leetcoding-challenge/week-1/verticalordertraversalofabinarytree/solution.go
+++ b/explore/other/card/august-leetcoding-challenge/week-1/verticalordertraversalofabinarytree/solution.go
@@ -1,0 +1,69 @@
+package verticalordertraversalofabinarytree
+
+import (
+	"sort"
+)
+
+type TreeNode struct {
+	Val   int
+	Left  *TreeNode
+	Right *TreeNode
+}
+
+// SeeAlso:
+// - https://leetcode.com/problems/vertical-order-traversal-of-a-binary-tree/discuss/659293/Super-simple-easy-to-understand-fast-basic-recursive-traversal-solution
+// - https://leetcode.com/problems/vertical-order-traversal-of-a-binary-tree/discuss/231113/C++-hashmap-vs.-map
+// - https://leetcode.com/problems/vertical-order-traversal-of-a-binary-tree/discuss/449743/Go-Level-order-traversal-with-memorization
+func verticalTraversal(root *TreeNode) [][]int {
+	max := func(x, y int) int {
+		if x > y {
+			return x
+		}
+		return y
+	}
+
+	levels := make(map[int]map[int][]int)
+	var deep int
+	var traversal func(node *TreeNode, w, d int)
+	traversal = func(node *TreeNode, w, d int) {
+		if node == nil {
+			return
+		}
+
+		deep = max(deep, d)
+		levelNodes, ok := levels[w]
+		if !ok {
+			levelNodes = make(map[int][]int)
+		}
+		levelNodes[d] = append(levelNodes[d], node.Val)
+		levels[w] = levelNodes
+
+		if node.Left != nil {
+			traversal(node.Left, w-1, d+1)
+		}
+
+		if node.Right != nil {
+			traversal(node.Right, w+1, d+1)
+		}
+	}
+
+	traversal(root, 0, 0)
+	out := make([][]int, 0)
+	for i := -1000; i <= 1000; i++ {
+		level, ok := levels[i]
+		if !ok {
+			continue
+		}
+		levelVals := make([]int, 0)
+		for j := 0; j <= deep; j++ {
+			vals, ok := level[j]
+			if !ok {
+				continue
+			}
+			sort.Ints(vals)
+			levelVals = append(levelVals, vals...)
+		}
+		out = append(out, levelVals)
+	}
+	return out
+}

--- a/explore/other/card/august-leetcoding-challenge/week-1/verticalordertraversalofabinarytree/solution_test.go
+++ b/explore/other/card/august-leetcoding-challenge/week-1/verticalordertraversalofabinarytree/solution_test.go
@@ -1,0 +1,52 @@
+package verticalordertraversalofabinarytree
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestVerticalTraversal(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		in   *TreeNode
+		want [][]int
+	}{
+		{in: &TreeNode{
+			Val:  3,
+			Left: &TreeNode{Val: 9},
+			Right: &TreeNode{
+				Val:   20,
+				Left:  &TreeNode{Val: 15},
+				Right: &TreeNode{Val: 7},
+			},
+		},
+			want: [][]int{{9}, {3, 15}, {20}, {7}},
+		},
+		{in: nil, want: [][]int{}},
+		{in: &TreeNode{
+			Val: 1,
+			Left: &TreeNode{Val: 2,
+				Left:  &TreeNode{Val: 4},
+				Right: &TreeNode{Val: 5},
+			},
+			Right: &TreeNode{
+				Val:   3,
+				Left:  &TreeNode{Val: 6},
+				Right: &TreeNode{Val: 7},
+			},
+		},
+			want: [][]int{{4}, {2}, {1, 5, 6}, {3}, {7}},
+		},
+	}
+	for i, tt := range tests {
+		i, tt := i, tt
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			t.Parallel()
+			got := verticalTraversal(tt.in)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("in: %v got: %v want: %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Intuition
- using preorder traversal recursion
- 幅をポインターとして使う
- [][]int{}な形に持って行き方に悩み、そこでフリーズ

## Note
- Discuss参照
- 幅と、深さのポインターが必要でした
- hashmap使って後で[][]intに作り変えるのか
- 参照後も、PythonとC++の実装を参考にやってみたがmap[int]map[int][]intで初期化したりなところで詰まる
  - 結果、goの実装を参考にrecursiveな実装